### PR TITLE
Fixed bug causing first init function argument to be accidentally overridden

### DIFF
--- a/thing.js
+++ b/thing.js
@@ -1,5 +1,6 @@
 var Thing = Object.create(null);
-Thing.create = function(proto, props, init) {
+Thing.create = function(proto, props, initialize) {
+  var init;
   if(typeof props === 'undefined'
       && typeof init === 'undefined'
       && !(proto instanceof Array))
@@ -7,6 +8,8 @@ Thing.create = function(proto, props, init) {
   else if(typeof props === 'boolean') {
     init = props;
     props = undefined;
+  } else {
+    init = initialize;
   }
 
   if(!(proto instanceof Array))


### PR DESCRIPTION
thing.js has a bug where the first argument after the init boolean will be overridden in case the optional propertiesObject argument it left out.

The problem is demonstrated by the following test:

``` javascript
var a = {
    init: function(name) {
        this.name = name;
    },
    sayHi: function() {
        alert("Hello, my name is " + this.name);
    }
}

var obj = Thing.create(a, true, "Simon");
obj.sayHi();
```

This code will alert "Hello, my name is true". Expected behavior is "Hello, my name is Simon".

The commit in this pull request contains a possible fix for the problem. Instead of modifying the arguments array, which causes the bug, it instead defines a local variable.
